### PR TITLE
Implement Mask Collision

### DIFF
--- a/src/entity.py
+++ b/src/entity.py
@@ -5,13 +5,21 @@ class Entity(pygame.sprite.Sprite):
     def __init__(self):
         super(Entity, self).__init__()
         self.base_image:pygame.image = None
-        self.rect:pygame.Rect = None
+        self._rect:pygame.Rect = None
         self.base_mask:pygame.mask = None    
         self.pos_x:float = 0
         self.pos_y:float = 0
         self.angle:float = 0
         self.scale:tuple[int, int] = (0, 0)
         self.alive = True
+
+    @property
+    def mask(self):
+        return self.getMask()
+
+    @property
+    def rect(self):
+        return self.getRect()
 
     def setPos(self, pos:tuple[int, int]=(0, 0)) -> None:
         self.pos_x = pos[0]
@@ -28,7 +36,7 @@ class Entity(pygame.sprite.Sprite):
     
     def setImage(self, image:pygame.surface.Surface, scale:tuple[float, float]) -> None:
         self.base_image = pygame.transform.scale(image, (scale[0], scale[1]))
-        self.rect = self.base_image.get_rect()
+        self._rect = self.base_image.get_rect()
     
     def getScale(self) -> tuple[float, float]:
         return self.scale

--- a/src/main.py
+++ b/src/main.py
@@ -68,24 +68,16 @@ def renderFrame():
             pygame.draw.circle(screen, obj['color'], obj['pos'], obj['radius'], obj['width'])
         
 
-## COLLISIONS
-def maskCollision(entityA:pygame.sprite.Sprite, entityB:pygame.sprite.Sprite):
-    rectA, maskA = entityA.getRect(), entityA.getMask()
-    rectB, maskB = entityB.getRect(), entityB.getMask()
-    offset_x = rectA.x - rectB.x
-    offset_y = rectA.y - rectB.y
-    collision = maskA.overlap(maskB, (offset_x, offset_y))
-    if collision:
-        print(f"{entityA} collided with {entityB}")
-    return collision if collision else None
 
 def collisionHandler():
-    for dood in doods:
-        close_food = pygame.sprite.spritecollideany(dood, foods)
-        if close_food:
-            collision = maskCollision(dood, close_food)
-            if collision:
-                close_food.alive = False
+    close_food = pygame.sprite.groupcollide(foods, doods, True, False, pygame.sprite.collide_mask)
+    if not close_food:
+        return
+
+    for food in close_food.keys():
+        print(f"Get eaten boiii! {food}")
+        food.alive = False
+
                 
 ### UPDATES
 def update(deltatime):


### PR DESCRIPTION
Just making that mask collision work and it somehow magically works. 

- add rect property inside Entity for that groupcollide function to work
- add mask property inside Entity for that mask collision

These new 2 properties inside Entity object really crucial since that groupcollide function need to see rect attribute from the sprite and that sprite.collide_mask need to see the mask.

I should rename that self._rect into something else but I'm too lazy :)